### PR TITLE
correct spelling of "English" and "日本語" in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,8 +2,8 @@
 
 このリポジトリは gem [active_record_compopse](https://github.com/hamajyotan/active_record_compose) を使ったサンプルアプリケーションです。
 
-- [README (engligh)](README.md)
-- [README (japanense)](README.ja.md)
+- [README (English)](README.md)
+- [README (日本語)](README.ja.md)
 
 簡易的なマイクロポストアプリケーションです。
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository is a sample application using the gem [active_record_compopse](https://github.com/hamajyotan/active_record_compose).
 
-- [README (engligh)](README.md)
-- [README (japanense)](README.ja.md)
+- [README (English)](README.md)
+- [README (日本語)](README.ja.md)
 
 This is a simple micropost application.
 


### PR DESCRIPTION
ドキュメントの正確性と日本語の読みやすさを向上させるための提案になります
