### PR TITLE
Revert "try to fix port forwarding"

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -12,9 +12,6 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    ports:
-    - "3000:3000"
-
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,20 @@
     "SELENIUM_HOST": "selenium"
   },
 
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [3000],
+  // A known problem is that this port forwarding configuration is not working properly right after codespace is started.
+  // PORTS > Visibility, change the setting that is currently /set to Private to Public, and immediately change it back to Private.
+  // This behavior seems to be a bug and is reported below.
+  // https://github.com/orgs/community/discussions/156546
 
+  // NOTE:
+  // When the forwardPorts setting exists, port forwarding does not work properly immediately after startup.
+  // As a workaround, changing the public range from Private -> Public -> Private will work, but it will work if this setting does not exist.
+  // Note that this bug does not occur when using images from “mcr.microsoft.com/devcontainers/ruby” instead of
+  // “ghcr.io/rails/devcontainer/images/ruby”. method provided by rails itself.
+  //
+  // "forwardPorts": [3000],
+
+  // Even without the “forwardPorts” setting above, the ports can be controlled by the “portsAttributes” directly below, which is sufficient.
   "portsAttributes": {
     "3000": {
       "label": "Application",
@@ -51,7 +62,7 @@
   "waitFor": "onCreateCommand",
   "updateContentCommand": "bundle install",
 
-  "postAttachCommand": "bin/rails server -b 0.0.0.0",
+  "postAttachCommand": "bin/rails server",
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bin/setup --skip-server"


### PR DESCRIPTION
Reverts hamajyotan/active_record_compose-example#29

Results of the study,

We decided that giving the `-rails server` the `-b` option was a bit of a hurdle, so we added the following